### PR TITLE
make sieve top level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["parse", "coyote", "html", "txml_string", "template_string", "coyote_html",]
+members = ["parse", "coyote", "html", "txml_string", "template_string", "coyote_html", "sieve",]
 resolver = "2"
 
 [workspace.dependencies]

--- a/coyote/src/lib.rs
+++ b/coyote/src/lib.rs
@@ -14,15 +14,6 @@ pub struct Template {
     pub injections: Vec<Component>,
 }
 
-// pub trait SieveImpl {
-//     fn respect_indentation(&self) -> bool;
-//     fn banned_el(&self, tag: &str) -> bool;
-//     fn void_el(&self, tag: &str) -> bool;
-//     fn namespace_el(&self, tag: &str) -> bool;
-//     fn preserved_text_el(&self, tag: &str) -> bool;
-//     fn inline_el(&self, tag: &str) -> bool;
-// }
-
 // ergonomic functions to quickly create componets without the typical rust verbosity
 //  (improves readability of component code considerably)
 pub fn tmpl<const N: usize>(template_str: &str, injections: [Component; N]) -> Component {

--- a/coyote/src/lib.rs
+++ b/coyote/src/lib.rs
@@ -1,4 +1,3 @@
-// Components are injected into templates
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Component {
     Text(String),
@@ -15,19 +14,17 @@ pub struct Template {
     pub injections: Vec<Component>,
 }
 
-pub trait SieveImpl {
-    fn respect_indentation(&self) -> bool;
-    fn banned_el(&self, tag: &str) -> bool;
-    fn void_el(&self, tag: &str) -> bool;
-    fn namespace_el(&self, tag: &str) -> bool;
-    fn preserved_text_el(&self, tag: &str) -> bool;
-    fn inline_el(&self, tag: &str) -> bool;
-}
+// pub trait SieveImpl {
+//     fn respect_indentation(&self) -> bool;
+//     fn banned_el(&self, tag: &str) -> bool;
+//     fn void_el(&self, tag: &str) -> bool;
+//     fn namespace_el(&self, tag: &str) -> bool;
+//     fn preserved_text_el(&self, tag: &str) -> bool;
+//     fn inline_el(&self, tag: &str) -> bool;
+// }
 
-// ergonomic functions to quickly create Component Enums
-//  (considerably improves readability of component code)
-
-// defacto template function
+// ergonomic functions to quickly create componets without the typical rust verbosity
+//  (improves readability of component code considerably)
 pub fn tmpl<const N: usize>(template_str: &str, injections: [Component; N]) -> Component {
     Component::Tmpl(Template {
         template_str: template_str.to_string(),

--- a/coyote_html/Cargo.toml
+++ b/coyote_html/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+sieve = { path = "../sieve" }
 html = { path = "../html" }
 coyote = { path = "../coyote" }
 txml_string = { path = "../txml_string" }

--- a/coyote_html/src/lib.rs
+++ b/coyote_html/src/lib.rs
@@ -2,16 +2,13 @@ pub use html::compose as pretty_html;
 pub use sieve::{ClientSieve, Sieve, SieveImpl};
 
 use coyote::Component;
-use html::compose as compose_html;
 use template_string::{compose as compose_template, BuilderImpl};
 use txml_string::{compose as compose_txml, Results as TxmlResults};
 
-// Builder without caching
-pub struct Builder {}
+pub struct Builder {
+    // place to cache txml results
+}
 
-// make builder an interface
-// then accept
-// pub TxmlResults
 impl Builder {
     pub fn new() -> Builder {
         Builder {}
@@ -25,7 +22,6 @@ impl BuilderImpl for Builder {
     }
 }
 
-// create Html with a builder in mind
 pub struct Html {
     pub builder: Builder,
 }

--- a/coyote_html/src/lib.rs
+++ b/coyote_html/src/lib.rs
@@ -1,7 +1,8 @@
 pub use html::compose as pretty_html;
-pub use html::sieves::{ClientSieve, Sieve, SieveImpl};
+pub use sieve::{ClientSieve, Sieve, SieveImpl};
 
 use coyote::Component;
+use html::compose as compose_html;
 use template_string::{compose as compose_template, BuilderImpl};
 use txml_string::{compose as compose_txml, Results as TxmlResults};
 
@@ -18,9 +19,9 @@ impl Builder {
 }
 
 impl BuilderImpl for Builder {
-    fn build(&mut self, template_str: &str) -> TxmlResults {
+    fn build(&mut self, sieve: &dyn SieveImpl, template_str: &str) -> TxmlResults {
         // chance to cache templates here
-        compose_txml(template_str)
+        compose_txml(sieve, template_str)
     }
 }
 
@@ -40,7 +41,8 @@ impl Html {
         Html { builder: builder }
     }
 
-    pub fn build(&mut self, component: &Component) -> String {
-        compose_template(&mut self.builder, component)
+    pub fn build(&mut self, sieve: &dyn SieveImpl, component: &Component) -> String {
+        compose_template(&mut self.builder, sieve, component)
+        // just go over with sieve again
     }
 }

--- a/coyote_html/tests/html_arc_mutex_tests.rs
+++ b/coyote_html/tests/html_arc_mutex_tests.rs
@@ -1,5 +1,5 @@
 use coyote::{attr_val, list, text, tmpl, Component};
-use coyote_html::{Builder, Html};
+use coyote_html::{Builder, Html, Sieve};
 
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -22,8 +22,9 @@ fn test_coyote_html_with_arc_and_mutex() {
     let arc = Arc::new(Mutex::new(html));
     let html_clone = arc.clone();
 
+    let sieve = Sieve::new();
     let woof_form = woof_woof();
     if let Ok(mut html_mutex) = html_clone.lock() {
-        let _results = html_mutex.build(&woof_form);
+        let _results = html_mutex.build(&sieve, &woof_form);
     };
 }

--- a/html/Cargo.toml
+++ b/html/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+sieve = { path = "../sieve" }
 parse = { path = "../parse" }
 coyote = { path = "../coyote" }

--- a/html/src/lib.rs
+++ b/html/src/lib.rs
@@ -1,10 +1,8 @@
 use parse::{get_text_from_step, parse_str, Step, StepKind};
 
 mod tag_info;
+use sieve::SieveImpl;
 use tag_info::{DescendantStatus, TagInfo};
-
-pub mod sieves;
-use sieves::SieveImpl;
 
 // intercept get_text_from_step
 // if step is a alt_step_close get tag

--- a/html/src/lib.rs
+++ b/html/src/lib.rs
@@ -4,9 +4,6 @@ mod tag_info;
 use sieve::SieveImpl;
 use tag_info::{DescendantStatus, TagInfo};
 
-// intercept get_text_from_step
-// if step is a alt_step_close get tag
-
 pub fn compose(sieve: &impl SieveImpl, template_str: &str) -> String {
     let mut results = "".to_string();
     let mut stack: Vec<TagInfo> = Vec::new();
@@ -121,14 +118,14 @@ fn push_element(
         }
     }
 
-    if sieve.respect_indentation() && !tag_info.inline_el && results.len() > 0 {
+    if sieve.respect_indentation() && results.len() > 0 && !tag_info.inline_el {
         // edge case that requires reading from the results to prevent starting with \n
         // not my favorite but works here
         results.push('\n');
         results.push_str(&"\t".repeat(tag_info.indent_count));
     }
 
-    if sieve.respect_indentation() && tag_info.inline_el && results.len() > 0 {
+    if sieve.respect_indentation() && results.len() > 0 && tag_info.inline_el {
         // edge case that requires reading from the results to prevent starting with \n
         // not my favorite but works here
         results.push(' ');
@@ -148,7 +145,6 @@ fn push_element(
 }
 
 fn close_element(results: &mut String, stack: &mut Vec<TagInfo>) {
-    // cannot close non existant tag
     let tag_info = match stack.last_mut() {
         Some(prev_tag_info) => prev_tag_info,
         _ => return,
@@ -197,7 +193,6 @@ fn pop_element(
     template_str: &str,
     step: Step,
 ) {
-    // need to get second to last element and then say this was a block element or an inline element
     let tag = get_text_from_step(template_str, &step);
 
     let tag_info = match stack.last() {
@@ -281,7 +276,7 @@ fn push_text(
         return;
     }
 
-    // if alternative like styles or scripts
+    // if alt text
     if let Some(_) = sieve.get_close_sequence_from_alt_text_tag(&tag_info.tag) {
         let common_index = get_most_common_space_index(text);
 

--- a/html/src/sieves.rs
+++ b/html/src/sieves.rs
@@ -1,202 +1,202 @@
-use coyote;
-use parse;
+// use coyote;
+// use parse;
 
-pub trait SieveImpl: parse::SieveImpl + coyote::SieveImpl {}
+// pub trait SieveImpl: parse::SieveImpl + coyote::SieveImpl {}
 
-pub struct Sieve {}
+// pub struct Sieve {}
 
-impl Sieve {
-    pub fn new() -> Sieve {
-        Sieve {}
-    }
-}
+// impl Sieve {
+//     pub fn new() -> Sieve {
+//         Sieve {}
+//     }
+// }
 
-impl SieveImpl for Sieve {}
+// impl SieveImpl for Sieve {}
 
-impl parse::SieveImpl for Sieve {
-    fn is_comment(&self, tag: &str) -> bool {
-        tag == "!--"
-    }
+// impl parse::SieveImpl for Sieve {
+//     fn is_comment(&self, tag: &str) -> bool {
+//         tag == "!--"
+//     }
 
-    fn get_close_sequence_from_alt_text_tag(&self, tag: &str) -> Option<&str> {
-        match tag {
-            "script" => Some("</script>"),
-            "style" => Some("</style>"),
-            "!--" => Some("-->"),
-            _ => None,
-        }
-    }
+//     fn get_close_sequence_from_alt_text_tag(&self, tag: &str) -> Option<&str> {
+//         match tag {
+//             "script" => Some("</script>"),
+//             "style" => Some("</style>"),
+//             "!--" => Some("-->"),
+//             _ => None,
+//         }
+//     }
 
-    fn get_tag_from_close_sequence(&self, tag: &str) -> Option<&str> {
-        match tag {
-            "</script>" => Some("script"),
-            "</style>" => Some("style"),
-            "-->" => Some("!--"),
-            _ => None,
-        }
-    }
-}
+//     fn get_tag_from_close_sequence(&self, tag: &str) -> Option<&str> {
+//         match tag {
+//             "</script>" => Some("script"),
+//             "</style>" => Some("style"),
+//             "-->" => Some("!--"),
+//             _ => None,
+//         }
+//     }
+// }
 
-impl coyote::SieveImpl for Sieve {
-    fn respect_indentation(&self) -> bool {
-        true
-    }
-    fn banned_el(&self, _tag: &str) -> bool {
-        false
-    }
-    fn void_el(&self, tag: &str) -> bool {
-        is_void_el(tag)
-    }
-    fn namespace_el(&self, tag: &str) -> bool {
-        is_namespace_el(tag)
-    }
-    fn preserved_text_el(&self, tag: &str) -> bool {
-        is_preserved_text_el(tag)
-    }
-    fn inline_el(&self, tag: &str) -> bool {
-        is_inline_el(tag)
-    }
-}
+// impl coyote::SieveImpl for Sieve {
+//     fn respect_indentation(&self) -> bool {
+//         true
+//     }
+//     fn banned_el(&self, _tag: &str) -> bool {
+//         false
+//     }
+//     fn void_el(&self, tag: &str) -> bool {
+//         is_void_el(tag)
+//     }
+//     fn namespace_el(&self, tag: &str) -> bool {
+//         is_namespace_el(tag)
+//     }
+//     fn preserved_text_el(&self, tag: &str) -> bool {
+//         is_preserved_text_el(tag)
+//     }
+//     fn inline_el(&self, tag: &str) -> bool {
+//         is_inline_el(tag)
+//     }
+// }
 
-pub struct ClientSieve {}
+// pub struct ClientSieve {}
 
-impl ClientSieve {
-    pub fn new() -> ClientSieve {
-        ClientSieve {}
-    }
-}
+// impl ClientSieve {
+//     pub fn new() -> ClientSieve {
+//         ClientSieve {}
+//     }
+// }
 
-impl SieveImpl for ClientSieve {}
+// impl SieveImpl for ClientSieve {}
 
-impl parse::SieveImpl for ClientSieve {
-    fn is_comment(&self, tag: &str) -> bool {
-        tag == "!--"
-    }
+// impl parse::SieveImpl for ClientSieve {
+//     fn is_comment(&self, tag: &str) -> bool {
+//         tag == "!--"
+//     }
 
-    fn get_close_sequence_from_alt_text_tag(&self, tag: &str) -> Option<&str> {
-        match tag {
-            "script" => Some("</script>"),
-            "style" => Some("</style>"),
-            "!--" => Some("-->"),
-            _ => None,
-        }
-    }
+//     fn get_close_sequence_from_alt_text_tag(&self, tag: &str) -> Option<&str> {
+//         match tag {
+//             "script" => Some("</script>"),
+//             "style" => Some("</style>"),
+//             "!--" => Some("-->"),
+//             _ => None,
+//         }
+//     }
 
-    fn get_tag_from_close_sequence(&self, tag: &str) -> Option<&str> {
-        match tag {
-            "</script>" => Some("script"),
-            "</style>" => Some("style"),
-            "-->" => Some("!--"),
-            _ => None,
-        }
-    }
-}
+//     fn get_tag_from_close_sequence(&self, tag: &str) -> Option<&str> {
+//         match tag {
+//             "</script>" => Some("script"),
+//             "</style>" => Some("style"),
+//             "-->" => Some("!--"),
+//             _ => None,
+//         }
+//     }
+// }
 
-impl coyote::SieveImpl for ClientSieve {
-    fn respect_indentation(&self) -> bool {
-        false
-    }
-    fn banned_el(&self, tag: &str) -> bool {
-        match tag {
-            "script" => true,
-            "style" => true,
-            _ => false,
-        }
-    }
-    fn void_el(&self, tag: &str) -> bool {
-        is_void_el(tag)
-    }
-    fn namespace_el(&self, tag: &str) -> bool {
-        is_namespace_el(tag)
-    }
-    fn preserved_text_el(&self, tag: &str) -> bool {
-        is_preserved_text_el(tag)
-    }
-    fn inline_el(&self, tag: &str) -> bool {
-        if tag == "a" {
-            return true;
-        }
+// impl coyote::SieveImpl for ClientSieve {
+//     fn respect_indentation(&self) -> bool {
+//         false
+//     }
+//     fn banned_el(&self, tag: &str) -> bool {
+//         match tag {
+//             "script" => true,
+//             "style" => true,
+//             _ => false,
+//         }
+//     }
+//     fn void_el(&self, tag: &str) -> bool {
+//         is_void_el(tag)
+//     }
+//     fn namespace_el(&self, tag: &str) -> bool {
+//         is_namespace_el(tag)
+//     }
+//     fn preserved_text_el(&self, tag: &str) -> bool {
+//         is_preserved_text_el(tag)
+//     }
+//     fn inline_el(&self, tag: &str) -> bool {
+//         if tag == "a" {
+//             return true;
+//         }
 
-        is_inline_el(tag)
-    }
-}
+//         is_inline_el(tag)
+//     }
+// }
 
-fn is_void_el(tag: &str) -> bool {
-    match tag {
-        "!DOCTYPE" => true,
-        "!--" => true,
-        "area" => true,
-        "base" => true,
-        "br" => true,
-        "col" => true,
-        "embed" => true,
-        "hr" => true,
-        "img" => true,
-        "input" => true,
-        "link" => true,
-        "meta" => true,
-        "param" => true,
-        "source" => true,
-        "track" => true,
-        "wbr" => true,
-        _ => false,
-    }
-}
+// fn is_void_el(tag: &str) -> bool {
+//     match tag {
+//         "!DOCTYPE" => true,
+//         "!--" => true,
+//         "area" => true,
+//         "base" => true,
+//         "br" => true,
+//         "col" => true,
+//         "embed" => true,
+//         "hr" => true,
+//         "img" => true,
+//         "input" => true,
+//         "link" => true,
+//         "meta" => true,
+//         "param" => true,
+//         "source" => true,
+//         "track" => true,
+//         "wbr" => true,
+//         _ => false,
+//     }
+// }
 
-fn is_namespace_el(tag: &str) -> bool {
-    match tag {
-        "html" => true,
-        "svg" => true,
-        "math" => true,
-        _ => false,
-    }
-}
+// fn is_namespace_el(tag: &str) -> bool {
+//     match tag {
+//         "html" => true,
+//         "svg" => true,
+//         "math" => true,
+//         _ => false,
+//     }
+// }
 
-pub fn is_preserved_text_el(tag: &str) -> bool {
-    return tag == "pre";
-}
+// pub fn is_preserved_text_el(tag: &str) -> bool {
+//     return tag == "pre";
+// }
 
-pub fn is_inline_el(tag: &str) -> bool {
-    match tag {
-        "abbr" => true,
-        "b" => true,
-        "bdi" => true,
-        "bdo" => true,
-        "cite" => true,
-        "code" => true,
-        "data" => true,
-        "dfn" => true,
-        "em" => true,
-        "i" => true,
-        "kbd" => true,
-        "mark" => true,
-        "q" => true,
-        "rp" => true,
-        "rt" => true,
-        "ruby" => true,
-        "s" => true,
-        "samp" => true,
-        "small" => true,
-        "span" => true,
-        "strong" => true,
-        "sub" => true,
-        "sup" => true,
-        "time" => true,
-        "u" => true,
-        "var" => true,
-        "wbr" => true,
-        "area" => true,
-        "audio" => true,
-        "img" => true,
-        "map" => true,
-        "track" => true,
-        "video" => true,
-        "embed" => true,
-        "iframe" => true,
-        "object" => true,
-        "picture" => true,
-        "portal" => true,
-        "source" => true,
-        _ => false,
-    }
-}
+// pub fn is_inline_el(tag: &str) -> bool {
+//     match tag {
+//         "abbr" => true,
+//         "b" => true,
+//         "bdi" => true,
+//         "bdo" => true,
+//         "cite" => true,
+//         "code" => true,
+//         "data" => true,
+//         "dfn" => true,
+//         "em" => true,
+//         "i" => true,
+//         "kbd" => true,
+//         "mark" => true,
+//         "q" => true,
+//         "rp" => true,
+//         "rt" => true,
+//         "ruby" => true,
+//         "s" => true,
+//         "samp" => true,
+//         "small" => true,
+//         "span" => true,
+//         "strong" => true,
+//         "sub" => true,
+//         "sup" => true,
+//         "time" => true,
+//         "u" => true,
+//         "var" => true,
+//         "wbr" => true,
+//         "area" => true,
+//         "audio" => true,
+//         "img" => true,
+//         "map" => true,
+//         "track" => true,
+//         "video" => true,
+//         "embed" => true,
+//         "iframe" => true,
+//         "object" => true,
+//         "picture" => true,
+//         "portal" => true,
+//         "source" => true,
+//         _ => false,
+//     }
+// }

--- a/html/src/tag_info.rs
+++ b/html/src/tag_info.rs
@@ -1,6 +1,6 @@
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element
 
-use crate::sieves::SieveImpl;
+use sieve::SieveImpl;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum DescendantStatus {
@@ -33,7 +33,7 @@ pub struct TagInfo {
 */
 
 impl TagInfo {
-    pub fn new(sieve: &impl SieveImpl, tag: &str) -> TagInfo {
+    pub fn new(sieve: &dyn SieveImpl, tag: &str) -> TagInfo {
         let mut namespace = "html".to_string();
         if sieve.namespace_el(tag) {
             namespace = tag.to_string()

--- a/html/tests/pretty_html_tests.rs
+++ b/html/tests/pretty_html_tests.rs
@@ -1,5 +1,5 @@
 use html::compose;
-use html::sieves::{ClientSieve, Sieve};
+use sieve::{ClientSieve, Sieve};
 
 #[test]
 fn test_pretty_html_no_empty_space() {

--- a/parse/Cargo.toml
+++ b/parse/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+sieve = { path = "../sieve" }

--- a/parse/src/lib.rs
+++ b/parse/src/lib.rs
@@ -3,6 +3,8 @@ mod sliding_window;
 
 use sliding_window::SlidingWindow;
 
+use sieve::SieveImpl;
+
 #[derive(Debug, Eq, Clone, PartialEq)]
 pub enum StepKind {
     AttrQuoteClosed,
@@ -33,12 +35,6 @@ pub enum StepKind {
     AltText,              //
     AltTextCloseSequence, //
     CommentText,          //
-}
-
-pub trait SieveImpl {
-    fn is_comment(&self, tag: &str) -> bool;
-    fn get_close_sequence_from_alt_text_tag(&self, tag: &str) -> Option<&str>;
-    fn get_tag_from_close_sequence(&self, tag: &str) -> Option<&str>;
 }
 
 #[derive(Debug, Eq, Clone, PartialEq)]

--- a/parse/src/lib.rs
+++ b/parse/src/lib.rs
@@ -50,7 +50,7 @@ pub struct Step {
 
 pub type Results = Vec<Step>;
 
-pub fn parse_str(sieve: &impl SieveImpl, template_str: &str, intial_kind: StepKind) -> Results {
+pub fn parse_str(sieve: &dyn SieveImpl, template_str: &str, intial_kind: StepKind) -> Results {
     let mut steps = Vec::from([Step {
         kind: intial_kind.clone(),
         origin: 0,
@@ -148,7 +148,7 @@ fn is_injection_kind(step_kind: &StepKind) -> bool {
 }
 
 fn add_reserved_element_text(
-    sieve: &impl SieveImpl,
+    sieve: &dyn SieveImpl,
     steps: &mut Vec<Step>,
     tag: &str,
     index: usize,

--- a/parse/src/lib.rs
+++ b/parse/src/lib.rs
@@ -32,9 +32,9 @@ pub enum StepKind {
     Tag,
     Text,
     // needed for comments and scripts
-    AltText,              //
-    AltTextCloseSequence, //
-    CommentText,          //
+    AltText,
+    AltTextCloseSequence,
+    CommentText,
 }
 
 #[derive(Debug, Eq, Clone, PartialEq)]

--- a/parse/tests/parse_tests.rs
+++ b/parse/tests/parse_tests.rs
@@ -1,42 +1,12 @@
-use parse::{parse_str, Results, SieveImpl, Step, StepKind};
+use parse::{parse_str, Results, Step, StepKind};
 
-pub struct TestSieve {}
-
-impl TestSieve {
-    fn new() -> TestSieve {
-        TestSieve {}
-    }
-}
-
-impl SieveImpl for TestSieve {
-    fn is_comment(&self, tag: &str) -> bool {
-        tag == "!--"
-    }
-
-    fn get_close_sequence_from_alt_text_tag(&self, tag: &str) -> Option<&str> {
-        match tag {
-            "script" => Some("</script>"),
-            "style" => Some("</style>"),
-            "!--" => Some("-->"),
-            _ => None,
-        }
-    }
-
-    fn get_tag_from_close_sequence(&self, tag: &str) -> Option<&str> {
-        match tag {
-            "</script>" => Some("script"),
-            "</style>" => Some("style"),
-            "-->" => Some("!--"),
-            _ => None,
-        }
-    }
-}
+use sieve::Sieve;
 
 /** DX **/
 // this test will fail to build if `clone` or `default formatter` is not available
 #[test]
 fn confirm_clone_and_debug() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "<fox>{}</fox>";
     let steps = parse_str(&sieve, template_str, StepKind::Initial);
@@ -48,7 +18,7 @@ fn confirm_clone_and_debug() {
 /** README EXAMPLE **/
 #[test]
 fn parse_readme_example() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "<fox>{}</fox>";
     let steps = parse_str(&sieve, template_str, StepKind::Initial);
@@ -111,7 +81,7 @@ fn parse_readme_example() {
 /** NODE TYPES **/
 #[test]
 fn parse_text() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "hai :3";
     let steps = parse_str(&sieve, template_str, StepKind::Initial);
@@ -133,7 +103,7 @@ fn parse_text() {
 
 #[test]
 fn parse_fragment() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "<>";
     let steps = parse_str(&sieve, template_str, StepKind::Text);
@@ -160,7 +130,7 @@ fn parse_fragment() {
 
 #[test]
 fn parse_close_fragment() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "</>";
     let steps = parse_str(&sieve, template_str, StepKind::FragmentClosed);
@@ -192,7 +162,7 @@ fn parse_close_fragment() {
 
 #[test]
 fn parse_node() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "<wolf>";
     let steps = parse_str(&sieve, template_str, StepKind::TailElementClosed);
@@ -224,7 +194,7 @@ fn parse_node() {
 
 #[test]
 fn parse_close_node() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "</wolf>";
     let steps = parse_str(&sieve, template_str, StepKind::FragmentClosed);
@@ -261,7 +231,7 @@ fn parse_close_node() {
 
 #[test]
 fn parse_void_node() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "<wolf/>";
     let steps = parse_str(&sieve, template_str, StepKind::TailElementClosed);
@@ -298,7 +268,7 @@ fn parse_void_node() {
 
 #[test]
 fn parse_all_nodes() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "
     	prarie
@@ -441,7 +411,7 @@ fn parse_all_nodes() {
 /** ATTRIBUTES **/
 #[test]
 fn parse_attribute() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "<hello howdy>";
     let steps = parse_str(&sieve, template_str, StepKind::Initial);
@@ -483,7 +453,7 @@ fn parse_attribute() {
 
 #[test]
 fn parse_multiple_attributes() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "<hello howdy look up occasionally>";
 
@@ -556,7 +526,7 @@ fn parse_multiple_attributes() {
 
 #[test]
 fn parse_attribute_declaration() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "<hello red=\"blue\">";
     let expected: Results = Vec::from([
@@ -618,7 +588,7 @@ fn parse_attribute_declaration() {
 
 #[test]
 fn parse_attribute_value_unquoted() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "<hello red=blue>";
     let expected: Results = Vec::from([
@@ -670,7 +640,7 @@ fn parse_attribute_value_unquoted() {
 
 #[test]
 fn parse_multiple_attribute_value_unquoted() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "<hello red=blue hia=:3 herro=!!!>";
     let expected: Results = Vec::from([
@@ -762,7 +732,7 @@ fn parse_multiple_attribute_value_unquoted() {
 
 #[test]
 fn parse_multiple_attribute_declaration() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "<hello red=\"blue\" orange=\"purple\" green=\"pink\">";
     let expected: Results = Vec::from([
@@ -884,7 +854,7 @@ fn parse_multiple_attribute_declaration() {
 
 #[test]
 fn parse_all_declarations() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "<hello red=\"blue\" wolf orange=\"purple\" tiger crane>";
     let expected: Results = Vec::from([
@@ -1007,7 +977,7 @@ fn parse_all_declarations() {
 /** INJECTIONS **/
 #[test]
 fn parse_descendant_injection() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "<hello>{}</hello>";
     let expected: Results = Vec::from([
@@ -1069,7 +1039,7 @@ fn parse_descendant_injection() {
 
 #[test]
 fn parse_multiple_descendant_injections() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "{}<hello>{}</hello>{}";
     let expected: Results = Vec::from([
@@ -1151,7 +1121,7 @@ fn parse_multiple_descendant_injections() {
 
 #[test]
 fn parse_attribute_injection() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "<hello {}>";
     let expected: Results = Vec::from([
@@ -1198,7 +1168,7 @@ fn parse_attribute_injection() {
 
 #[test]
 fn parse_multiple_attribute_injections() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "<hello {} {} world {}>";
     let expected: Results = Vec::from([
@@ -1285,7 +1255,7 @@ fn parse_multiple_attribute_injections() {
 
 #[test]
 fn parse_all_injections() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "
     	<hello world {} {} howdy>
@@ -1441,7 +1411,7 @@ fn parse_all_injections() {
 /** RELIABLE CHAOS **/
 #[test]
 fn parse_a_mangled_mess() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template_str: &str = "
 			<			moon phase=				text_that_is_very_bad_and_does_not_belong

--- a/parse/tests/parse_tests.rs
+++ b/parse/tests/parse_tests.rs
@@ -1,11 +1,45 @@
-use parse::{parse_template_str, Results, Step, StepKind};
+use parse::{parse_str, Results, SieveImpl, Step, StepKind};
+
+pub struct TestSieve {}
+
+impl TestSieve {
+    fn new() -> TestSieve {
+        TestSieve {}
+    }
+}
+
+impl SieveImpl for TestSieve {
+    fn is_comment(&self, tag: &str) -> bool {
+        tag == "!--"
+    }
+
+    fn get_close_sequence_from_alt_text_tag(&self, tag: &str) -> Option<&str> {
+        match tag {
+            "script" => Some("</script>"),
+            "style" => Some("</style>"),
+            "!--" => Some("-->"),
+            _ => None,
+        }
+    }
+
+    fn get_tag_from_close_sequence(&self, tag: &str) -> Option<&str> {
+        match tag {
+            "</script>" => Some("script"),
+            "</style>" => Some("style"),
+            "-->" => Some("!--"),
+            _ => None,
+        }
+    }
+}
 
 /** DX **/
 // this test will fail to build if `clone` or `default formatter` is not available
 #[test]
 fn confirm_clone_and_debug() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "<fox>{}</fox>";
-    let steps = parse_template_str(template_str, StepKind::Initial);
+    let steps = parse_str(&sieve, template_str, StepKind::Initial);
 
     let cloned = steps.clone();
     let _debugged = format!("{:?}", cloned);
@@ -14,8 +48,10 @@ fn confirm_clone_and_debug() {
 /** README EXAMPLE **/
 #[test]
 fn parse_readme_example() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "<fox>{}</fox>";
-    let steps = parse_template_str(template_str, StepKind::Initial);
+    let steps = parse_str(&sieve, template_str, StepKind::Initial);
     let expected: Results = Vec::from([
         Step {
             kind: StepKind::Initial,
@@ -75,8 +111,10 @@ fn parse_readme_example() {
 /** NODE TYPES **/
 #[test]
 fn parse_text() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "hai :3";
-    let steps = parse_template_str(template_str, StepKind::Initial);
+    let steps = parse_str(&sieve, template_str, StepKind::Initial);
     let expected: Results = Vec::from([
         Step {
             kind: StepKind::Initial,
@@ -95,8 +133,10 @@ fn parse_text() {
 
 #[test]
 fn parse_fragment() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "<>";
-    let steps = parse_template_str(template_str, StepKind::Text);
+    let steps = parse_str(&sieve, template_str, StepKind::Text);
     let expected: Results = Vec::from([
         Step {
             kind: StepKind::Text,
@@ -120,8 +160,10 @@ fn parse_fragment() {
 
 #[test]
 fn parse_close_fragment() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "</>";
-    let steps = parse_template_str(template_str, StepKind::FragmentClosed);
+    let steps = parse_str(&sieve, template_str, StepKind::FragmentClosed);
     let expected: Results = Vec::from([
         Step {
             kind: StepKind::FragmentClosed,
@@ -150,8 +192,10 @@ fn parse_close_fragment() {
 
 #[test]
 fn parse_node() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "<wolf>";
-    let steps = parse_template_str(template_str, StepKind::TailElementClosed);
+    let steps = parse_str(&sieve, template_str, StepKind::TailElementClosed);
     let expected: Results = Vec::from([
         Step {
             kind: StepKind::TailElementClosed,
@@ -180,8 +224,10 @@ fn parse_node() {
 
 #[test]
 fn parse_close_node() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "</wolf>";
-    let steps = parse_template_str(template_str, StepKind::FragmentClosed);
+    let steps = parse_str(&sieve, template_str, StepKind::FragmentClosed);
     let expected: Results = Vec::from([
         Step {
             kind: StepKind::FragmentClosed,
@@ -215,8 +261,10 @@ fn parse_close_node() {
 
 #[test]
 fn parse_void_node() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "<wolf/>";
-    let steps = parse_template_str(template_str, StepKind::TailElementClosed);
+    let steps = parse_str(&sieve, template_str, StepKind::TailElementClosed);
     let expected: Results = Vec::from([
         Step {
             kind: StepKind::TailElementClosed,
@@ -250,6 +298,8 @@ fn parse_void_node() {
 
 #[test]
 fn parse_all_nodes() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "
     	prarie
     	<>
@@ -261,7 +311,7 @@ fn parse_all_nodes() {
     	</>
     	chase the sun
     ";
-    let steps = parse_template_str(template_str, StepKind::Initial);
+    let steps = parse_str(&sieve, template_str, StepKind::Initial);
     let expected: Results = Vec::from([
         Step {
             kind: StepKind::Initial,
@@ -391,8 +441,10 @@ fn parse_all_nodes() {
 /** ATTRIBUTES **/
 #[test]
 fn parse_attribute() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "<hello howdy>";
-    let steps = parse_template_str(template_str, StepKind::Initial);
+    let steps = parse_str(&sieve, template_str, StepKind::Initial);
     let expected: Results = Vec::from([
         Step {
             kind: StepKind::Initial,
@@ -431,6 +483,8 @@ fn parse_attribute() {
 
 #[test]
 fn parse_multiple_attributes() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "<hello howdy look up occasionally>";
 
     let expected: Results = Vec::from([
@@ -496,12 +550,14 @@ fn parse_multiple_attributes() {
         },
     ]);
 
-    let steps = parse_template_str(template_str, StepKind::Initial);
+    let steps = parse_str(&sieve, template_str, StepKind::Initial);
     assert_eq!(steps, expected);
 }
 
 #[test]
 fn parse_attribute_declaration() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "<hello red=\"blue\">";
     let expected: Results = Vec::from([
         Step {
@@ -556,12 +612,14 @@ fn parse_attribute_declaration() {
         },
     ]);
 
-    let steps = parse_template_str(template_str, StepKind::Initial);
+    let steps = parse_str(&sieve, template_str, StepKind::Initial);
     assert_eq!(steps, expected);
 }
 
 #[test]
 fn parse_attribute_value_unquoted() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "<hello red=blue>";
     let expected: Results = Vec::from([
         Step {
@@ -606,12 +664,14 @@ fn parse_attribute_value_unquoted() {
         },
     ]);
 
-    let steps = parse_template_str(template_str, StepKind::Initial);
+    let steps = parse_str(&sieve, template_str, StepKind::Initial);
     assert_eq!(steps, expected);
 }
 
 #[test]
 fn parse_multiple_attribute_value_unquoted() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "<hello red=blue hia=:3 herro=!!!>";
     let expected: Results = Vec::from([
         Step {
@@ -696,12 +756,14 @@ fn parse_multiple_attribute_value_unquoted() {
         },
     ]);
 
-    let steps = parse_template_str(template_str, StepKind::Initial);
+    let steps = parse_str(&sieve, template_str, StepKind::Initial);
     assert_eq!(steps, expected);
 }
 
 #[test]
 fn parse_multiple_attribute_declaration() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "<hello red=\"blue\" orange=\"purple\" green=\"pink\">";
     let expected: Results = Vec::from([
         Step {
@@ -816,12 +878,14 @@ fn parse_multiple_attribute_declaration() {
         },
     ]);
 
-    let steps = parse_template_str(template_str, StepKind::Initial);
+    let steps = parse_str(&sieve, template_str, StepKind::Initial);
     assert_eq!(steps, expected);
 }
 
 #[test]
 fn parse_all_declarations() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "<hello red=\"blue\" wolf orange=\"purple\" tiger crane>";
     let expected: Results = Vec::from([
         Step {
@@ -936,13 +1000,15 @@ fn parse_all_declarations() {
         },
     ]);
 
-    let steps = parse_template_str(template_str, StepKind::Initial);
+    let steps = parse_str(&sieve, template_str, StepKind::Initial);
     assert_eq!(steps, expected);
 }
 
 /** INJECTIONS **/
 #[test]
 fn parse_descendant_injection() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "<hello>{}</hello>";
     let expected: Results = Vec::from([
         Step {
@@ -997,12 +1063,14 @@ fn parse_descendant_injection() {
         },
     ]);
 
-    let steps = parse_template_str(template_str, StepKind::Initial);
+    let steps = parse_str(&sieve, template_str, StepKind::Initial);
     assert_eq!(steps, expected);
 }
 
 #[test]
 fn parse_multiple_descendant_injections() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "{}<hello>{}</hello>{}";
     let expected: Results = Vec::from([
         Step {
@@ -1077,12 +1145,14 @@ fn parse_multiple_descendant_injections() {
         },
     ]);
 
-    let steps = parse_template_str(template_str, StepKind::Initial);
+    let steps = parse_str(&sieve, template_str, StepKind::Initial);
     assert_eq!(steps, expected);
 }
 
 #[test]
 fn parse_attribute_injection() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "<hello {}>";
     let expected: Results = Vec::from([
         Step {
@@ -1122,12 +1192,14 @@ fn parse_attribute_injection() {
         },
     ]);
 
-    let steps = parse_template_str(template_str, StepKind::Initial);
+    let steps = parse_str(&sieve, template_str, StepKind::Initial);
     assert_eq!(steps, expected);
 }
 
 #[test]
 fn parse_multiple_attribute_injections() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "<hello {} {} world {}>";
     let expected: Results = Vec::from([
         Step {
@@ -1207,12 +1279,14 @@ fn parse_multiple_attribute_injections() {
         },
     ]);
 
-    let steps = parse_template_str(template_str, StepKind::Initial);
+    let steps = parse_str(&sieve, template_str, StepKind::Initial);
     assert_eq!(steps, expected);
 }
 
 #[test]
 fn parse_all_injections() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "
     	<hello world {} {} howdy>
     		what's good!
@@ -1360,20 +1434,22 @@ fn parse_all_injections() {
         },
     ]);
 
-    let steps = parse_template_str(template_str, StepKind::Initial);
+    let steps = parse_str(&sieve, template_str, StepKind::Initial);
     assert_eq!(steps, expected);
 }
 
 /** RELIABLE CHAOS **/
 #[test]
 fn parse_a_mangled_mess() {
+    let sieve = TestSieve::new();
+
     let template_str: &str = "
 			<			moon phase=				text_that_is_very_bad_and_does_not_belong
 	\"waxing gibbous\"					/					><
 clouds           big            opacity=\"0.9\"
 >
 ";
-    let steps = parse_template_str(template_str, StepKind::Initial);
+    let steps = parse_str(&sieve, template_str, StepKind::Initial);
     let expected: Results = Vec::from([
         Step {
             kind: StepKind::Initial,

--- a/parse/tests/parse_with_reserved_tags_tests.rs
+++ b/parse/tests/parse_with_reserved_tags_tests.rs
@@ -1,41 +1,11 @@
-use parse::{parse_str, Results, SieveImpl, Step, StepKind};
+use parse::{parse_str, Results, Step, StepKind};
 
-pub struct TestSieve {}
-
-impl TestSieve {
-    fn new() -> TestSieve {
-        TestSieve {}
-    }
-}
-
-impl SieveImpl for TestSieve {
-    fn is_comment(&self, tag: &str) -> bool {
-        tag == "!--"
-    }
-
-    fn get_close_sequence_from_alt_text_tag(&self, tag: &str) -> Option<&str> {
-        match tag {
-            "script" => Some("</script>"),
-            "style" => Some("</style>"),
-            "!--" => Some("-->"),
-            _ => None,
-        }
-    }
-
-    fn get_tag_from_close_sequence(&self, tag: &str) -> Option<&str> {
-        match tag {
-            "</script>" => Some("script"),
-            "</style>" => Some("style"),
-            "-->" => Some("!--"),
-            _ => None,
-        }
-    }
-}
+use sieve::Sieve;
 
 #[test]
 fn confirm_clone_and_debug() {
     let template_str: &str = "<fox>{}</fox>";
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let steps = parse_str(&sieve, template_str, StepKind::Initial);
     let cloned = steps.clone();
@@ -46,7 +16,7 @@ fn confirm_clone_and_debug() {
 #[test]
 fn parse_text() {
     let template_str: &str = "hai :3";
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let steps = parse_str(&sieve, template_str, StepKind::Initial);
     let expected: Results = Vec::from([
@@ -69,7 +39,7 @@ fn parse_text() {
 #[test]
 fn parse_reserved_tag() {
     let template_str: &str = "<style>.fox{color: auburn;}</style>";
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let steps = parse_str(&sieve, template_str, StepKind::Initial);
     let expected = [
@@ -111,7 +81,7 @@ fn parse_reserved_tag() {
 #[test]
 fn parse_reserved_tag_comment() {
     let template_str: &str = "<!-- imma pup! bork! -->";
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let steps = parse_str(&sieve, template_str, StepKind::Initial);
     let expected: Results = Vec::from([
@@ -148,7 +118,7 @@ fn parse_reserved_tag_comment() {
 #[test]
 fn parse_nested_reserved_tag() {
     let template_str: &str = "<fox><style>.fox{color: auburn;}</style></fox>";
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let steps = parse_str(&sieve, template_str, StepKind::Initial);
 
@@ -227,7 +197,7 @@ fn parse_nested_reserved_tag() {
 fn parse_multiple_sieve() {
     let template_str: &str =
         "<style>.fox{color: auburn;}</style><script>console.log('hai :3')</script>";
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let steps = parse_str(&sieve, template_str, StepKind::Initial);
 
@@ -296,7 +266,7 @@ fn parse_multiple_sieve() {
 fn cannot_parse_nested_sieve() {
     let template_str: &str =
         "<script><style>.fox{color: auburn;}</style>console.log('hai :3')</script>";
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let steps = parse_str(&sieve, template_str, StepKind::Initial);
 

--- a/sieve/Cargo.toml
+++ b/sieve/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "sieve"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/sieve/src/lib.rs
+++ b/sieve/src/lib.rs
@@ -1,0 +1,214 @@
+pub trait ParseSieveImpl {
+    fn is_comment(&self, tag: &str) -> bool;
+    fn get_close_sequence_from_alt_text_tag(&self, tag: &str) -> Option<&str>;
+    fn get_tag_from_close_sequence(&self, tag: &str) -> Option<&str>;
+}
+
+pub trait CoyoteSieveImpl {
+    fn respect_indentation(&self) -> bool;
+    fn banned_el(&self, tag: &str) -> bool;
+    fn void_el(&self, tag: &str) -> bool;
+    fn namespace_el(&self, tag: &str) -> bool;
+    fn preserved_text_el(&self, tag: &str) -> bool;
+    fn inline_el(&self, tag: &str) -> bool;
+}
+
+pub trait SieveImpl: ParseSieveImpl + CoyoteSieveImpl {}
+
+pub struct Sieve {}
+
+impl Sieve {
+    pub fn new() -> Sieve {
+        Sieve {}
+    }
+}
+
+impl SieveImpl for Sieve {}
+
+impl ParseSieveImpl for Sieve {
+    fn is_comment(&self, tag: &str) -> bool {
+        tag == "!--"
+    }
+
+    fn get_close_sequence_from_alt_text_tag(&self, tag: &str) -> Option<&str> {
+        match tag {
+            "script" => Some("</script>"),
+            "style" => Some("</style>"),
+            "!--" => Some("-->"),
+            _ => None,
+        }
+    }
+
+    fn get_tag_from_close_sequence(&self, tag: &str) -> Option<&str> {
+        match tag {
+            "</script>" => Some("script"),
+            "</style>" => Some("style"),
+            "-->" => Some("!--"),
+            _ => None,
+        }
+    }
+}
+
+impl CoyoteSieveImpl for Sieve {
+    fn respect_indentation(&self) -> bool {
+        true
+    }
+    fn banned_el(&self, _tag: &str) -> bool {
+        false
+    }
+    fn void_el(&self, tag: &str) -> bool {
+        is_void_el(tag)
+    }
+    fn namespace_el(&self, tag: &str) -> bool {
+        is_namespace_el(tag)
+    }
+    fn preserved_text_el(&self, tag: &str) -> bool {
+        is_preserved_text_el(tag)
+    }
+    fn inline_el(&self, tag: &str) -> bool {
+        is_inline_el(tag)
+    }
+}
+
+pub struct ClientSieve {}
+
+impl ClientSieve {
+    pub fn new() -> ClientSieve {
+        ClientSieve {}
+    }
+}
+
+impl SieveImpl for ClientSieve {}
+
+impl ParseSieveImpl for ClientSieve {
+    fn is_comment(&self, tag: &str) -> bool {
+        tag == "!--"
+    }
+
+    fn get_close_sequence_from_alt_text_tag(&self, tag: &str) -> Option<&str> {
+        match tag {
+            "script" => Some("</script>"),
+            "style" => Some("</style>"),
+            "!--" => Some("-->"),
+            _ => None,
+        }
+    }
+
+    fn get_tag_from_close_sequence(&self, tag: &str) -> Option<&str> {
+        match tag {
+            "</script>" => Some("script"),
+            "</style>" => Some("style"),
+            "-->" => Some("!--"),
+            _ => None,
+        }
+    }
+}
+
+impl CoyoteSieveImpl for ClientSieve {
+    fn respect_indentation(&self) -> bool {
+        false
+    }
+    fn banned_el(&self, tag: &str) -> bool {
+        match tag {
+            "script" => true,
+            "style" => true,
+            _ => false,
+        }
+    }
+    fn void_el(&self, tag: &str) -> bool {
+        is_void_el(tag)
+    }
+    fn namespace_el(&self, tag: &str) -> bool {
+        is_namespace_el(tag)
+    }
+    fn preserved_text_el(&self, tag: &str) -> bool {
+        is_preserved_text_el(tag)
+    }
+    fn inline_el(&self, tag: &str) -> bool {
+        if tag == "a" {
+            return true;
+        }
+
+        is_inline_el(tag)
+    }
+}
+
+fn is_void_el(tag: &str) -> bool {
+    match tag {
+        "!DOCTYPE" => true,
+        "!--" => true,
+        "area" => true,
+        "base" => true,
+        "br" => true,
+        "col" => true,
+        "embed" => true,
+        "hr" => true,
+        "img" => true,
+        "input" => true,
+        "link" => true,
+        "meta" => true,
+        "param" => true,
+        "source" => true,
+        "track" => true,
+        "wbr" => true,
+        _ => false,
+    }
+}
+
+fn is_namespace_el(tag: &str) -> bool {
+    match tag {
+        "html" => true,
+        "svg" => true,
+        "math" => true,
+        _ => false,
+    }
+}
+
+pub fn is_preserved_text_el(tag: &str) -> bool {
+    return tag == "pre";
+}
+
+pub fn is_inline_el(tag: &str) -> bool {
+    match tag {
+        "abbr" => true,
+        "b" => true,
+        "bdi" => true,
+        "bdo" => true,
+        "cite" => true,
+        "code" => true,
+        "data" => true,
+        "dfn" => true,
+        "em" => true,
+        "i" => true,
+        "kbd" => true,
+        "mark" => true,
+        "q" => true,
+        "rp" => true,
+        "rt" => true,
+        "ruby" => true,
+        "s" => true,
+        "samp" => true,
+        "small" => true,
+        "span" => true,
+        "strong" => true,
+        "sub" => true,
+        "sup" => true,
+        "time" => true,
+        "u" => true,
+        "var" => true,
+        "wbr" => true,
+        "area" => true,
+        "audio" => true,
+        "img" => true,
+        "map" => true,
+        "track" => true,
+        "video" => true,
+        "embed" => true,
+        "iframe" => true,
+        "object" => true,
+        "picture" => true,
+        "portal" => true,
+        "source" => true,
+        _ => false,
+    }
+}

--- a/template_string/Cargo.toml
+++ b/template_string/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+sieve = { path = "../sieve" }
 parse = { path = "../parse" }
 coyote = { path = "../coyote" }
 txml_string = { path = "../txml_string" }

--- a/template_string/src/lib.rs
+++ b/template_string/src/lib.rs
@@ -1,4 +1,8 @@
+/* */
+
 use coyote::Component;
+use parse::SieveImpl;
+
 use parse::StepKind;
 use txml_string::Results;
 
@@ -13,28 +17,21 @@ enum StackBit<'a> {
 }
 
 pub trait BuilderImpl {
-    fn build(&mut self, template_str: &str) -> Results;
+    fn build(&mut self, sieve: &dyn SieveImpl, template_str: &str) -> Results;
 }
 
-// this needs a context to retain a scope for chaching.
-// this way renders are
-
-// There are three sections that are basically copy paste.
-// They need to be in the same function / ownership scope?
-// Cannot mutable borrow more than once.
-// Rail programming makes it impossible to swap a self.propert
-// (builder, template) = build(builder, template_str)
-// (self.builder, template) = build(builer, template_str)
-
-pub fn compose(builder: &mut dyn BuilderImpl, component: &Component) -> String {
+pub fn compose(
+    builder: &mut dyn BuilderImpl,
+    sieve: &impl SieveImpl,
+    component: &Component,
+) -> String {
     let mut templ_str = "".to_string();
 
     let sbit = match component {
         Component::Text(_text) => StackBit::Cmpnt(component),
         Component::List(_list) => StackBit::Cmpnt(component),
         Component::Tmpl(tmpl) => {
-            // chance to cache templates here
-            let txml_literal = builder.build(&tmpl.template_str);
+            let txml_literal = builder.build(sieve, &tmpl.template_str);
             StackBit::Tmpl(component, txml_literal, TemplateBit { inj_index: 0 })
         }
         _ => StackBit::None,
@@ -52,8 +49,7 @@ pub fn compose(builder: &mut dyn BuilderImpl, component: &Component) -> String {
                             Component::Text(_text) => StackBit::Cmpnt(cmpnt),
                             Component::List(_list) => StackBit::Cmpnt(cmpnt),
                             Component::Tmpl(tmpl) => {
-                                // chance to cache templates here
-                                let txml_literal = builder.build(&tmpl.template_str);
+                                let txml_literal = builder.build(sieve, &tmpl.template_str);
                                 StackBit::Tmpl(cmpnt, txml_literal, TemplateBit { inj_index: 0 })
                             }
                             _ => StackBit::None,
@@ -65,8 +61,6 @@ pub fn compose(builder: &mut dyn BuilderImpl, component: &Component) -> String {
                 _ => {}
             },
             StackBit::Tmpl(component, ref results, ref mut bit) => {
-                // templates will be N + 1
-                // injections will be length N
                 let index = bit.inj_index;
                 bit.inj_index += 1;
 
@@ -95,7 +89,7 @@ pub fn compose(builder: &mut dyn BuilderImpl, component: &Component) -> String {
                                     Component::List(_list) => StackBit::Cmpnt(inj),
                                     Component::Tmpl(tmpl) => {
                                         // chance to cache templates here
-                                        let txml_literal = builder.build(&tmpl.template_str);
+                                        let txml_literal = builder.build(sieve, &tmpl.template_str);
                                         StackBit::Tmpl(
                                             inj,
                                             txml_literal,

--- a/template_string/src/lib.rs
+++ b/template_string/src/lib.rs
@@ -1,7 +1,5 @@
-/* */
-
 use coyote::Component;
-use parse::SieveImpl;
+use sieve::SieveImpl;
 
 use parse::StepKind;
 use txml_string::Results;
@@ -22,7 +20,7 @@ pub trait BuilderImpl {
 
 pub fn compose(
     builder: &mut dyn BuilderImpl,
-    sieve: &impl SieveImpl,
+    sieve: &dyn SieveImpl,
     component: &Component,
 ) -> String {
     let mut templ_str = "".to_string();

--- a/template_string/tests/template_string_builder_tests.rs
+++ b/template_string/tests/template_string_builder_tests.rs
@@ -1,8 +1,41 @@
 use coyote::{attr_val, list, text, tmpl, Component};
+use parse::SieveImpl;
 use template_string::{compose as compose_template, BuilderImpl};
 use txml_string::{compose as compose_txml, Results};
 
 // Test will not build if Function Components do not build
+
+pub struct TestSieve {}
+
+impl TestSieve {
+    fn new() -> TestSieve {
+        TestSieve {}
+    }
+}
+
+impl SieveImpl for TestSieve {
+    fn is_comment(&self, tag: &str) -> bool {
+        tag == "!--"
+    }
+
+    fn get_close_sequence_from_alt_text_tag(&self, tag: &str) -> Option<&str> {
+        match tag {
+            "script" => Some("</script>"),
+            "style" => Some("</style>"),
+            "!--" => Some("-->"),
+            _ => None,
+        }
+    }
+
+    fn get_tag_from_close_sequence(&self, tag: &str) -> Option<&str> {
+        match tag {
+            "</script>" => Some("script"),
+            "</style>" => Some("style"),
+            "-->" => Some("!--"),
+            _ => None,
+        }
+    }
+}
 
 pub struct TxmlBuilder {}
 
@@ -13,9 +46,9 @@ impl TxmlBuilder {
 }
 
 impl BuilderImpl for TxmlBuilder {
-    fn build(&mut self, template_str: &str) -> Results {
+    fn build(&mut self, sieve: &dyn SieveImpl, template_str: &str) -> Results {
         // chance to cache templates here
-        compose_txml(template_str)
+        compose_txml(sieve, template_str)
     }
 }
 
@@ -33,7 +66,9 @@ fn woof_woof() -> Component {
 
 #[test]
 fn test_static_template_builder() {
+    let sieve = TestSieve::new();
+
     let mut builder = TxmlBuilder::new();
     let template = woof_woof();
-    let _results = compose_template(&mut builder, &template);
+    let _results = compose_template(&mut builder, &sieve, &template);
 }

--- a/template_string/tests/template_string_builder_tests.rs
+++ b/template_string/tests/template_string_builder_tests.rs
@@ -1,41 +1,9 @@
 use coyote::{attr_val, list, text, tmpl, Component};
-use parse::SieveImpl;
+use sieve::{Sieve, SieveImpl};
 use template_string::{compose as compose_template, BuilderImpl};
 use txml_string::{compose as compose_txml, Results};
 
 // Test will not build if Function Components do not build
-
-pub struct TestSieve {}
-
-impl TestSieve {
-    fn new() -> TestSieve {
-        TestSieve {}
-    }
-}
-
-impl SieveImpl for TestSieve {
-    fn is_comment(&self, tag: &str) -> bool {
-        tag == "!--"
-    }
-
-    fn get_close_sequence_from_alt_text_tag(&self, tag: &str) -> Option<&str> {
-        match tag {
-            "script" => Some("</script>"),
-            "style" => Some("</style>"),
-            "!--" => Some("-->"),
-            _ => None,
-        }
-    }
-
-    fn get_tag_from_close_sequence(&self, tag: &str) -> Option<&str> {
-        match tag {
-            "</script>" => Some("script"),
-            "</style>" => Some("style"),
-            "-->" => Some("!--"),
-            _ => None,
-        }
-    }
-}
 
 pub struct TxmlBuilder {}
 
@@ -47,7 +15,6 @@ impl TxmlBuilder {
 
 impl BuilderImpl for TxmlBuilder {
     fn build(&mut self, sieve: &dyn SieveImpl, template_str: &str) -> Results {
-        // chance to cache templates here
         compose_txml(sieve, template_str)
     }
 }
@@ -66,7 +33,7 @@ fn woof_woof() -> Component {
 
 #[test]
 fn test_static_template_builder() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let mut builder = TxmlBuilder::new();
     let template = woof_woof();

--- a/txml_string/Cargo.toml
+++ b/txml_string/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+sieve = { path = "../sieve" }
 parse = { path = "../parse" }
 coyote = { path = "../coyote" }

--- a/txml_string/src/lib.rs
+++ b/txml_string/src/lib.rs
@@ -5,10 +5,9 @@ use sieve::SieveImpl;
 /*
     INTERMEDIATE RENDER FORMAT
 
-    Uses the Parse crate to get steps.
     Templates are converted to an array of content[] and injections[].
 
-    Although Coyote currently focuses on a text / string environment
+    Coyote is focused on text / strings
 */
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/txml_string/src/lib.rs
+++ b/txml_string/src/lib.rs
@@ -1,4 +1,6 @@
-use parse::{get_text_from_step, parse_str, SieveImpl, Step, StepKind};
+use parse::{get_text_from_step, parse_str, Step, StepKind};
+
+use sieve::SieveImpl;
 
 // this should be called TEMPLATE STRING
 /*

--- a/txml_string/src/lib.rs
+++ b/txml_string/src/lib.rs
@@ -1,4 +1,14 @@
-use parse::{get_text_from_step, parse_template_str, Step, StepKind};
+use parse::{get_text_from_step, parse_str, SieveImpl, Step, StepKind};
+
+// this should be called TEMPLATE STRING
+/*
+    INTERMEDIATE RENDER FORMAT
+
+    Uses the Parse crate to get steps.
+    Templates are converted to an array of content[] and injections[].
+
+    Although Coyote currently focuses on a text / string environment
+*/
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Results {
@@ -15,99 +25,18 @@ impl Results {
     }
 }
 
-// can this be skipped entirely?
-// just add all steps?
-// skip the bullshit
-// only split on injections
-
-// this needs to be a function
-// this is what is cached by a parent scope or context
-pub fn compose(template_str: &str) -> Results {
-    // check for already built results
+pub fn compose(sieve: &dyn SieveImpl, template_str: &str) -> Results {
     let mut results = Results::new();
 
-    for step in parse_template_str(template_str, StepKind::Initial) {
+    for step in parse_str(sieve, template_str, StepKind::Initial) {
         match step.kind {
-            // steps
-            StepKind::Tag => push_element(&mut results, template_str, step),
-            StepKind::Attr => add_attr(&mut results, template_str, step),
-            StepKind::AttrValueUnquoted => {
-                add_attr_value_unquoted(&mut results, template_str, step)
-            }
-            StepKind::AttrValue => add_attr_value(&mut results, template_str, step),
-            StepKind::ElementClosed => close_element(&mut results),
-            StepKind::EmptyElementClosed => empty_void_element(&mut results),
-            StepKind::TailTag => pop_element(&mut results, template_str, step),
-            StepKind::Text => push_text(&mut results, template_str, step),
-            // alt text
-            // comment text
-            // alt text closing sequence
-            // injections
             StepKind::AttrMapInjection => push_attr_map_injection(&mut results),
             StepKind::DescendantInjection => push_descendant_injection(&mut results),
-            _ => {}
+            _ => push_text(&mut results, template_str, step),
         }
     }
 
     results
-}
-
-fn push_element(results: &mut Results, template_str: &str, step: Step) {
-    let tag = get_text_from_step(template_str, &step);
-
-    if let Some(last) = results.strs.last_mut() {
-        last.push('<');
-        last.push_str(tag);
-    }
-}
-
-fn add_attr(results: &mut Results, template_str: &str, step: Step) {
-    let attr = get_text_from_step(template_str, &step);
-
-    if let Some(last) = results.strs.last_mut() {
-        last.push(' ');
-        last.push_str(attr);
-    }
-}
-
-fn add_attr_value_unquoted(results: &mut Results, template_str: &str, step: Step) {
-    let attr_val = get_text_from_step(template_str, &step);
-
-    if let Some(last) = results.strs.last_mut() {
-        last.push('=');
-        last.push_str(attr_val);
-    }
-}
-
-fn add_attr_value(results: &mut Results, template_str: &str, step: Step) {
-    let attr_val = get_text_from_step(template_str, &step);
-
-    if let Some(last) = results.strs.last_mut() {
-        last.push_str("=\"");
-        last.push_str(attr_val);
-        last.push('"');
-    }
-}
-
-fn close_element(results: &mut Results) {
-    if let Some(last) = results.strs.last_mut() {
-        last.push_str(">");
-    }
-}
-
-fn empty_void_element(results: &mut Results) {
-    if let Some(last) = results.strs.last_mut() {
-        last.push_str("/>");
-    }
-}
-
-fn pop_element(results: &mut Results, template_str: &str, step: Step) {
-    let tag = get_text_from_step(template_str, &step);
-    if let Some(last) = results.strs.last_mut() {
-        last.push_str("</");
-        last.push_str(tag);
-        last.push_str(">");
-    }
 }
 
 fn push_text(results: &mut Results, template_str: &str, step: Step) {

--- a/txml_string/src/lib.rs
+++ b/txml_string/src/lib.rs
@@ -2,7 +2,6 @@ use parse::{get_text_from_step, parse_str, Step, StepKind};
 
 use sieve::SieveImpl;
 
-// this should be called TEMPLATE STRING
 /*
     INTERMEDIATE RENDER FORMAT
 

--- a/txml_string/tests/txml_string_builder_tests.rs
+++ b/txml_string/tests/txml_string_builder_tests.rs
@@ -1,8 +1,41 @@
 use coyote::{attr_val, list, text, tmpl, Component};
+use parse::SieveImpl;
 
 use txml_string::compose;
 
 // Test will not build if Function Components do not build
+
+pub struct TestSieve {}
+
+impl TestSieve {
+    fn new() -> TestSieve {
+        TestSieve {}
+    }
+}
+
+impl SieveImpl for TestSieve {
+    fn is_comment(&self, tag: &str) -> bool {
+        tag == "!--"
+    }
+
+    fn get_close_sequence_from_alt_text_tag(&self, tag: &str) -> Option<&str> {
+        match tag {
+            "script" => Some("</script>"),
+            "style" => Some("</style>"),
+            "!--" => Some("-->"),
+            _ => None,
+        }
+    }
+
+    fn get_tag_from_close_sequence(&self, tag: &str) -> Option<&str> {
+        match tag {
+            "</script>" => Some("script"),
+            "</style>" => Some("style"),
+            "-->" => Some("!--"),
+            _ => None,
+        }
+    }
+}
 
 fn woof() -> Component {
     tmpl("<input type=submit value=\"yus -_-\">", [])
@@ -18,9 +51,11 @@ fn woof_woof() -> Component {
 
 #[test]
 fn test_txml_builder() {
+    let sieve = TestSieve::new();
+
     let template = woof_woof();
 
     if let Component::Tmpl(tmpl) = template {
-        let _results = compose(&tmpl.template_str);
+        let _results = compose(&sieve, &tmpl.template_str);
     }
 }

--- a/txml_string/tests/txml_string_builder_tests.rs
+++ b/txml_string/tests/txml_string_builder_tests.rs
@@ -1,41 +1,9 @@
 use coyote::{attr_val, list, text, tmpl, Component};
-use parse::SieveImpl;
+use sieve::Sieve;
 
 use txml_string::compose;
 
 // Test will not build if Function Components do not build
-
-pub struct TestSieve {}
-
-impl TestSieve {
-    fn new() -> TestSieve {
-        TestSieve {}
-    }
-}
-
-impl SieveImpl for TestSieve {
-    fn is_comment(&self, tag: &str) -> bool {
-        tag == "!--"
-    }
-
-    fn get_close_sequence_from_alt_text_tag(&self, tag: &str) -> Option<&str> {
-        match tag {
-            "script" => Some("</script>"),
-            "style" => Some("</style>"),
-            "!--" => Some("-->"),
-            _ => None,
-        }
-    }
-
-    fn get_tag_from_close_sequence(&self, tag: &str) -> Option<&str> {
-        match tag {
-            "</script>" => Some("script"),
-            "</style>" => Some("style"),
-            "-->" => Some("!--"),
-            _ => None,
-        }
-    }
-}
 
 fn woof() -> Component {
     tmpl("<input type=submit value=\"yus -_-\">", [])
@@ -51,7 +19,7 @@ fn woof_woof() -> Component {
 
 #[test]
 fn test_txml_builder() {
-    let sieve = TestSieve::new();
+    let sieve = Sieve::new();
 
     let template = woof_woof();
 


### PR DESCRIPTION
I could not get rust to recognize a composite implementation was the superset of atomic implementations.

impl1 + impl2 = impl3
impl3!(impl1)