### PR TITLE
escape curly brackets

### DIFF
--- a/coyote/src/lib.rs
+++ b/coyote/src/lib.rs
@@ -24,7 +24,10 @@ pub fn tmpl<const N: usize>(template_str: &str, injections: [Component; N]) -> C
 }
 
 pub fn text(txt: &str) -> Component {
-    let escaped = txt.replace("<", "&lt;").replace("&", "&amp;").replace("{", "&#123;");
+    let escaped = txt
+        .replace("<", "&lt;")
+        .replace("&", "&amp;")
+        .replace("{", "&#123;");
     Component::Text(escaped)
 }
 

--- a/coyote/src/lib.rs
+++ b/coyote/src/lib.rs
@@ -24,7 +24,7 @@ pub fn tmpl<const N: usize>(template_str: &str, injections: [Component; N]) -> C
 }
 
 pub fn text(txt: &str) -> Component {
-    let escaped = txt.replace("<", "&lt;").replace("&", "&amp;");
+    let escaped = txt.replace("<", "&lt;").replace("&", "&amp;").replace("{", "&#123;");
     Component::Text(escaped)
 }
 


### PR DESCRIPTION
After intermediate render format is created, brackets from text will be interpreted as injections. Escape the initial bracket with `&#123;`.